### PR TITLE
Now can write stripped geotiffs

### DIFF
--- a/sptw.h
+++ b/sptw.h
@@ -23,7 +23,11 @@
 #include <mpi.h>
 
 #include <string>
+#if HAVE_STDINT_H == 0
 #include <cstdint>
+#else
+#include <stdint.h>
+#endif
 
 using std::string;
 
@@ -90,7 +94,8 @@ namespace sptw {
     };
 
     SPTW_ERROR populate_tile_offsets(PTIFF *tiff_file,
-            int64_t tile_size);
+            int64_t tile_size,
+            bool tiled);
 
     SPTW_ERROR create_raster(string filename,
             int64_t x_size,


### PR DESCRIPTION
Allow SPTW to write striped images (faster writing).
The two behaviors (Striped/Tiled) can be switched at the populate offsets step by changing the optional "tiled" variable (false/true). Default is the original SPTW behavior (tiled=true) in order to keep backward compatibility with pRasterBlaster.

A minor change is the testing of HAVE_STDINT_H in order to chose between the include <cstdint> or <stdint.h>, this allows to compile fine with or without c++11
